### PR TITLE
Add webpackIgnore to dynamic imports

### DIFF
--- a/esm/interpreters.js
+++ b/esm/interpreters.js
@@ -26,7 +26,7 @@ export const interpreter = new Proxy(new Map(), {
                 : interpreter.module(...rest);
             map.set(id, {
                 url,
-                module: import(url),
+                module: import(/* webpackIgnore: true */url),
                 engine: interpreter.engine.bind(interpreter),
             });
         }

--- a/esm/toml.js
+++ b/esm/toml.js
@@ -5,4 +5,4 @@ const TOML_LIB = 'https://cdn.jsdelivr.net/npm/basic-toml@0.3.1/es.js';
  * @param {string} text TOML text to parse
  * @returns {object} the resulting JS object
  */
-export const parse = async (text) => (await import(TOML_LIB)).parse(text);
+export const parse = async (text) => (await import(/* webpackIgnore: true */TOML_LIB)).parse(text);


### PR DESCRIPTION
The comment webpackIgnore tells webpack to treat these imports as dynamic ones and not try to resolve it.
The other approaches like updating externals doesn't work.  Fixes #18 