### PR TITLE
Fix #66 - Use new hooks for all smoke tests and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -424,7 +424,7 @@ The *core* module itself exposes two methods to do so:
 
 | name          | example                   | behavior |
 | :------------ | :------------------------ | :--------|
-| define        | `define('mpy', options)`  | Register once a `<script type="mpy">`, if it's a string, and a counter `<mpy-script>` selector that will bootstrap and handle all nodes in the page that match such selectors. If the `type` is either `null` or `undefined`, no type will exist but the interpreter will be bootstrapped anyway, hence available once `options.onInterpreterReady(wrap)` is invoked (without any `element` reference). The available `options` are described after this table. |
+| define        | `define('mpy', options)`  | Register once a `<script type="mpy">`, if it's a string, and a counter `<mpy-script>` selector that will bootstrap and handle all nodes in the page that match such selectors. If the `type` is either `null` or `undefined`, no type will exist but the interpreter will be bootstrapped anyway, hence available once `options.hooks.main.onReady(wrap)` is invoked (without any `element` reference). The available `options` are described after this table. |
 | whenDefined        | `whenDefined('mpy')` | Return a promise that will be resolved once the custom `mpy` script will be available, returning an *interpreter* wrapper once it will be fully ready. |
 
 ```js
@@ -606,7 +606,7 @@ Whenever a *non-custom* script is going to run some code, or whenever *any worke
 
 ### Custom Types on Main
 
-The reason this event is not automatically dispatched on custom type elements or scripts is that these will have their own `onInterpreterReady` hook to eventually do more before desiring, or needing, to notify the "*readiness*" of such custom element and, in case of wanting the event to happen, this is the tiny boilerplate needed to simulate otherwise non-custom type events:
+The reason this event is not automatically dispatched on custom type elements or scripts is that these will have their own `options.hooks.main.onReady` hook to eventually do more before desiring, or needing, to notify the "*readiness*" of such custom element and, in case of wanting the event to happen, this is the tiny boilerplate needed to simulate otherwise non-custom type events:
 
 ```js
 // note: type === 'py' or the defined type

--- a/test/custom.html
+++ b/test/custom.html
@@ -17,16 +17,20 @@
         define('mpy', {
           config,
           interpreter: 'micropython',
-          onInterpreterReady(wrap, element) {
-            console.assert(
-              JSON.stringify(wrap.config) === JSON.stringify(config),
-              'not the same config'
-            );
-            wrap.run(element.textContent);
-            const button = document.createElement('button');
-            button.setAttribute('mpy-click', 'all_good');
-            button.textContent = 'runtime';
-            document.body.append(button);
+          hooks: {
+            main: {
+              onReady(wrap, element) {
+                console.assert(
+                  JSON.stringify(wrap.config) === JSON.stringify(config),
+                  'not the same config'
+                );
+                wrap.run(element.textContent);
+                const button = document.createElement('button');
+                button.setAttribute('mpy-click', 'all_good');
+                button.textContent = 'runtime';
+                document.body.append(button);
+              }
+            }
           }
         });
     </script>

--- a/test/events.html
+++ b/test/events.html
@@ -19,14 +19,18 @@
       import { define } from "/core.js";
       define("mpy", {
         interpreter: 'micropython',
-        onInterpreterReady({ run, type }, element) {
-          element.dispatchEvent(
-            new CustomEvent(`${type}:ready`, {
-              bubbles: true,
-              detail: { worker: false },
-            })
-          );
-          run(element.textContent);
+        hooks: {
+          main: {
+            onReady({ run, type }, element) {
+              element.dispatchEvent(
+                new CustomEvent(`${type}:ready`, {
+                  bubbles: true,
+                  detail: { worker: false },
+                })
+              );
+              run(element.textContent);
+            }
+          }
         }
       });
     </script>

--- a/test/interpreter.html
+++ b/test/interpreter.html
@@ -13,11 +13,15 @@
           interpreter: 'micropython',
           // version: '1.20.0-295',
           // version: 'https://cdn.jsdelivr.net/npm/@micropython/micropython-webassembly-pyscript@1.20.0-295/micropython.mjs',
-          onInterpreterReady({ run }, element) {
-            run(`
-              import sys
-              print(sys.version)
-            `);
+          hooks: {
+            main: {
+              onReady({ run }, element) {
+                run(`
+                  import sys
+                  print(sys.version)
+                `);
+              }
+            }
           }
         });
     </script>

--- a/test/plugins/index.html
+++ b/test/plugins/index.html
@@ -18,30 +18,34 @@
             define("mpy", {
                 interpreter: "micropython",
                 config: "../fetch.toml",
-                async onInterpreterReady(micropython, element) {
-                    console.log(micropython);
-                    // Somehow this doesn't work in MicroPython
-                    micropython.io.stdout = (message) => {
-                        console.log("🐍", micropython.type, message);
-                    };
-                    micropython.io.stderr = (message) => {
-                        console.error("⚠️🐍", message);
-                    };
+                hooks: {
+                    main: {
+                        async onReady(micropython, element) {
+                            console.log(micropython);
+                            // Somehow this doesn't work in MicroPython
+                            micropython.io.stdout = (message) => {
+                                console.log("🐍", micropython.type, message);
+                            };
+                            micropython.io.stderr = (message) => {
+                                console.error("⚠️🐍", message);
+                            };
 
-                    micropython.run(element.textContent);
-                    element.replaceChildren("See console ->");
-                    element.style.display = "block";
+                            micropython.run(element.textContent);
+                            element.replaceChildren("See console ->");
+                            element.style.display = "block";
 
-                    const button = document.createElement("button");
-                    button.textContent = "click";
-                    button.setAttribute("mpy-click", "test_click");
-                    document.body.append(button);
+                            const button = document.createElement("button");
+                            button.textContent = "click";
+                            button.setAttribute("mpy-click", "test_click");
+                            document.body.append(button);
 
-                    const error = document.createElement("button");
-                    error.textContent = "error";
-                    error.setAttribute("mpy-click", "test_error");
-                    document.body.append(error);
-                },
+                            const error = document.createElement("button");
+                            error.textContent = "error";
+                            error.setAttribute("mpy-click", "test_error");
+                            document.body.append(error);
+                        }
+                    }
+                }
             });
         </script>
     </head>

--- a/test/plugins/lua.html
+++ b/test/plugins/lua.html
@@ -16,15 +16,19 @@
             import { define } from "polyscript";
             define("lua", {
                 interpreter: "wasmoon",
-                async onInterpreterReady(wasmoon, element) {
-                    // Somehow this doesn't work in Wasmoon
-                    wasmoon.io.stdout = (message) => {
-                        console.log("🌑", wasmoon.type, message);
-                    };
-                    wasmoon.run(element.textContent);
-                    element.replaceChildren("See console ->");
-                    element.style.display = "block";
-                },
+                hooks: {
+                    main: {
+                        async onReady(wasmoon, element) {
+                            // Somehow this doesn't work in Wasmoon
+                            wasmoon.io.stdout = (message) => {
+                                console.log("🌑", wasmoon.type, message);
+                            };
+                            wasmoon.run(element.textContent);
+                            element.replaceChildren("See console ->");
+                            element.style.display = "block";
+                        },
+                    }
+                }
             });
         </script>
     </head>

--- a/test/queue/index.html
+++ b/test/queue/index.html
@@ -8,11 +8,15 @@
     import { define } from "../../core.js";
     define("mpy", {
       interpreter: "micropython",
-      async onInterpreterReady({ run }, element) {
-        let code = element.textContent;
-        if (element.src)
-          code = await fetch(element.src).then(b => b.text());
-        run(code);
+      hooks: {
+        main: {
+          async onReady({ run }, element) {
+            let code = element.textContent;
+            if (element.src)
+              code = await fetch(element.src).then(b => b.text());
+            run(code);
+          }
+        }
       }
     });
   </script>


### PR DESCRIPTION
This MR simply updates all smoke tests to use latest hooks that landed in polyscript.