### PR TITLE
fix: disable packages cache when local wheels are detected

### DIFF
--- a/esm/interpreter/pyodide.js
+++ b/esm/interpreter/pyodide.js
@@ -95,6 +95,15 @@ export default {
             progress('Loading remote packages');
             config.packages = (packages = await _remote_package([config, baseURL], packages));
             progress('Loaded remote packages');
+            // Detect local wheels: packages that are paths (./ ../ / emfs:// file://)
+            // or URLs ending in .whl. When local wheels are present, disable IndexedDB
+            // caching unless the user explicitly sets packages_cache = "all".
+            // See https://github.com/pyscript/pyscript/issues/2282
+            if (packages && packages.some(pkg => /^(?:\.{1,2}\/|\/|emfs:\/\/|file:\/\/)/.test(pkg) || /\.whl(?:\?|$)/.test(pkg))) {
+                if (config.packages_cache !== 'all') {
+                    config.packages_cache = 'never';
+                }
+            }
         }
         progress('Loading Storage');
         const indexURL = url.slice(0, url.lastIndexOf('/'));

--- a/esm/interpreter/pyodide.js
+++ b/esm/interpreter/pyodide.js
@@ -99,7 +99,7 @@ export default {
             // or URLs ending in .whl. When local wheels are present, disable IndexedDB
             // caching unless the user explicitly sets packages_cache = "all".
             // See https://github.com/pyscript/pyscript/issues/2282
-            if (packages && packages.some(pkg => /^(?:\.{1,2}\/|\/|emfs:\/\/|file:\/\/)/.test(pkg) || /\.whl(?:\?|$)/.test(pkg))) {
+            if (packages && packages.some(pkg => /^(?:\.{1,2}\/|\/|(?:emfs|file):\/\/)/.test(pkg) || /\.whl(?:\?|$)/.test(pkg))) {
                 if (config.packages_cache !== 'all') {
                     config.packages_cache = 'never';
                 }


### PR DESCRIPTION
## Description

Fixes pyscript/pyscript#2282

When local **.whl** files are specified in the `packages` list, their dependencies fail to resolve on subsequent page loads because `micropip.freeze()` stores stale absolute or virtual filesystem references in IndexedDB. On the next page load, the frozen lockfile is restored instead of running `micropip.install()`, causing `ModuleNotFoundError` for the wheel's dependencies.

This is somewhat of a band-aid fix, based on the following [response](https://github.com/pyscript/pyscript/issues/2282#issuecomment-3645691730):

> There are cache cases we were hoping to easily control out of the micropip box but if we need to orchestrate anything "that convoluted" you are actually better off without the cache because nothing else would be necessarily faster but it's something to consider/think about sooner than later.

## Solution

This change automatically sets `packages_cache` to `'never'` when local wheels are detected in the packages array. Local wheels are identified by:
- Paths starting with `./`, `../`, `/`, `emfs://`, `file://`
- URLs ending with `.whl`

Users can still explicitly opt into caching with `packages_cache = "all"`.

## Related

- Issue: https://github.com/pyscript/pyscript/issues/2282
- Previous partial fix: https://github.com/pyscript/pyscript/issues/2228